### PR TITLE
Add codex environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Install dependencies using `pip`:
 pip install langchain langsmith openai
 ```
 
+Alternatively, you can use the included `codex.yaml` to configure the
+environment automatically. The setup step installs the dependencies from
+`requirements.txt`, while credentials must be supplied through environment
+variables.
+
 Set the following environment variables with your credentials:
 
 - `OPENAI_API_KEY`

--- a/codex.yaml
+++ b/codex.yaml
@@ -1,0 +1,8 @@
+image: python:3.10
+setup:
+  - pip install -r requirements.txt
+run: python main.py
+env:
+  OPENAI_API_KEY: ${OPENAI_API_KEY}
+  LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
+  LANGCHAIN_ENDPOINT: ${LANGCHAIN_ENDPOINT}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+langchain
+langsmith
+openai


### PR DESCRIPTION
## Summary
- add `codex.yaml` to define the runtime environment
- list dependencies in `requirements.txt`
- mention the codex configuration in the README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6860ef29bfe883329c9e6621c1fd5090