### PR TITLE
Add Codespace configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+    "name": "MyLangSmith",
+    "image": "mcr.microsoft.com/devcontainers/python:0-3.10",
+    "postCreateCommand": "pip install -r requirements.txt",
+    "remoteEnv": {
+        "OPENAI_API_KEY": "${OPENAI_API_KEY}",
+        "LANGCHAIN_API_KEY": "${LANGCHAIN_API_KEY}",
+        "LANGCHAIN_ENDPOINT": "${LANGCHAIN_ENDPOINT}"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Install dependencies using `pip`:
 pip install langchain langsmith openai
 ```
 
+Alternatively, you can spin up a Codespace and the `.devcontainer` configuration
+will install the dependencies automatically. Credentials must still be provided
+through environment variables.
+
 Set the following environment variables with your credentials:
 
 - `OPENAI_API_KEY`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+langchain
+langsmith
+openai


### PR DESCRIPTION
## Summary
- replace `codex.yaml` with GitHub Codespaces setup
- document how to use the `.devcontainer` environment

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6860ef29bfe883329c9e6621c1fd5090