### PR TITLE
Implement basic FIPA ACL demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,13 @@ Execute `main.py` to run a simple `LLMChain` that greets the user. The run is re
 python main.py
 ```
 
+## FIPA ACL Demo
+
+The repository also includes a minimal skeleton that demonstrates how multiple agents
+can communicate using the FIPA ACL protocol. Run `fipa_demo.py` to see two agents
+exchange `request` and `inform` messages via a simple in-memory message bus.
+
+```bash
+python fipa_demo.py
+```
+

--- a/fipa_acl.py
+++ b/fipa_acl.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+import uuid
+
+
+@dataclass
+class FIPAMessage:
+    """Minimal representation of a FIPA ACL message."""
+
+    performative: str
+    sender: str
+    receiver: str
+    content: str
+    conversation_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+
+
+class MessageBus:
+    """Simple in-memory message bus for agents."""
+
+    def __init__(self) -> None:
+        self.agents: Dict[str, FIPAAgent] = {}
+
+    def register(self, agent: 'FIPAAgent') -> None:
+        self.agents[agent.name] = agent
+
+    def send(self, message: FIPAMessage) -> None:
+        receiver = self.agents.get(message.receiver)
+        if receiver:
+            receiver.receive(message)
+
+
+class FIPAAgent:
+    """Base class for agents communicating via FIPA ACL."""
+
+    def __init__(self, name: str, bus: MessageBus) -> None:
+        self.name = name
+        self.bus = bus
+        self.inbox: List[FIPAMessage] = []
+        self.bus.register(self)
+
+    def send(self, receiver: str, performative: str, content: str) -> None:
+        message = FIPAMessage(
+            performative=performative,
+            sender=self.name,
+            receiver=receiver,
+            content=content,
+        )
+        self.bus.send(message)
+
+    def receive(self, message: FIPAMessage) -> None:
+        self.inbox.append(message)
+        self.on_message(message)
+
+    def on_message(self, message: FIPAMessage) -> None:
+        """Handle an incoming message. Override in subclasses."""
+        print(
+            f"{self.name} received {message.performative} from {message.sender}: {message.content}"
+        )

--- a/fipa_demo.py
+++ b/fipa_demo.py
@@ -1,0 +1,24 @@
+from fipa_acl import FIPAAgent, MessageBus
+
+
+class EchoAgent(FIPAAgent):
+    """Agent that echoes back any request as an inform message."""
+
+    def on_message(self, message):
+        super().on_message(message)
+        if message.performative == "request":
+            reply = f"ack: {message.content}"
+            self.send(message.sender, "inform", reply)
+
+
+def main() -> None:
+    bus = MessageBus()
+    alice = EchoAgent("Alice", bus)
+    bob = EchoAgent("Bob", bus)
+
+    alice.send("Bob", "request", "Hello Bob")
+    bob.send("Alice", "request", "Hello Alice")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `FIPAMessage`, `MessageBus`, and `FIPAAgent` for minimal FIPA ACL support
- provide `fipa_demo.py` demo showing two agents exchanging messages
- update README with instructions to run the new demo

## Testing
- `python fipa_demo.py`
- `python -m py_compile fipa_acl.py fipa_demo.py`


------
https://chatgpt.com/codex/tasks/task_e_6862557f06c883328c73ff9be3d823a8