### PR TITLE
Implement OpenAI-powered websocket agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,19 @@ exchange `request` and `inform` messages via a simple in-memory message bus.
 python fipa_demo.py
 ```
 
+## Commander/Executor WebSocket Demo
+
+Two additional agents showcase communication over websockets with LLM-powered
+reasoning. The Commander sends human language instructions, while the Executor
+converts them to shell commands using OpenAI, runs them, and summarizes the
+output back to the Commander.
+
+Run the demo with:
+
+```bash
+python commander_executor.py
+```
+
+Ensure the `OPENAI_API_KEY` environment variable is set for the agents to call
+the OpenAI API.
+

--- a/commander_executor.py
+++ b/commander_executor.py
@@ -1,0 +1,107 @@
+import asyncio
+import openai
+
+from websocket_bus import WebSocketMessageBus
+from websocket_agent import WebSocketFIPAAgent
+from fipa_acl import FIPAMessage
+
+
+class CommanderAgent(WebSocketFIPAAgent):
+    async def run(self) -> None:
+        await self.connect()
+        while True:
+            user_cmd = await asyncio.to_thread(
+                input, "Введите команду (или 'exit'): "
+            )
+            if user_cmd.lower() == "exit":
+                break
+            completion = await openai.ChatCompletion.acreate(
+                model="gpt-3.5-turbo",
+                messages=[
+                    {
+                        "role": "system",
+                        "content": (
+                            "Сформулируй короткую инструкцию выполнить команду в shell."
+                        ),
+                    },
+                    {"role": "user", "content": user_cmd},
+                ],
+            )
+            instruction = completion.choices[0].message["content"].strip()
+            await self.send("Executor", "request", instruction)
+        await asyncio.sleep(1)
+
+    async def on_message(self, message: FIPAMessage) -> None:
+        await super().on_message(message)
+        if message.performative == "inform":
+            completion = await openai.ChatCompletion.acreate(
+                model="gpt-3.5-turbo",
+                messages=[
+                    {
+                        "role": "system",
+                        "content": (
+                            "Подтверди получение и кратко опиши результат выполнения."
+                        ),
+                    },
+                    {"role": "user", "content": message.content},
+                ],
+            )
+            print(completion.choices[0].message["content"].strip())
+
+
+class ExecutorAgent(WebSocketFIPAAgent):
+    async def on_message(self, message: FIPAMessage) -> None:
+        await super().on_message(message)
+        if message.performative == "request":
+            completion = await openai.ChatCompletion.acreate(
+                model="gpt-3.5-turbo",
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "Преобразуй инструкцию пользователя в команду shell.",
+                    },
+                    {"role": "user", "content": message.content},
+                ],
+            )
+            cmd = completion.choices[0].message["content"].strip()
+            proc = await asyncio.create_subprocess_shell(
+                cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            out, _ = await proc.communicate()
+            output = out.decode().strip()
+            completion = await openai.ChatCompletion.acreate(
+                model="gpt-3.5-turbo",
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "Опиши результат выполнения команды пользователю.",
+                    },
+                    {
+                        "role": "user",
+                        "content": f"Команда: {cmd}\nВывод: {output}",
+                    },
+                ],
+            )
+            reply = completion.choices[0].message["content"].strip()
+            await self.send(message.sender, "inform", reply)
+
+
+async def main() -> None:
+    bus = WebSocketMessageBus()
+    server_task = asyncio.create_task(bus.start())
+
+    executor = ExecutorAgent("Executor", "ws://localhost:8765")
+    await executor.connect()
+
+    commander = CommanderAgent("Commander", "ws://localhost:8765")
+    await commander.run()
+
+    await commander.websocket.close()
+    await executor.websocket.close()
+    server_task.cancel()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/fipa_acl.py
+++ b/fipa_acl.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict, List, Optional
 import uuid
 
 
@@ -34,13 +34,16 @@ class MessageBus:
 class FIPAAgent:
     """Base class for agents communicating via FIPA ACL."""
 
-    def __init__(self, name: str, bus: MessageBus) -> None:
+    def __init__(self, name: str, bus: Optional[MessageBus] = None) -> None:
         self.name = name
         self.bus = bus
         self.inbox: List[FIPAMessage] = []
-        self.bus.register(self)
+        if self.bus is not None:
+            self.bus.register(self)
 
     def send(self, receiver: str, performative: str, content: str) -> None:
+        if self.bus is None:
+            raise RuntimeError("Agent is not connected to a message bus")
         message = FIPAMessage(
             performative=performative,
             sender=self.name,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 langchain
 openai
+websockets

--- a/websocket_agent.py
+++ b/websocket_agent.py
@@ -1,0 +1,35 @@
+import asyncio
+import json
+import websockets
+from fipa_acl import FIPAMessage, FIPAAgent
+
+
+class WebSocketFIPAAgent(FIPAAgent):
+    """FIPA agent that communicates over a websocket."""
+
+    def __init__(self, name: str, uri: str) -> None:
+        super().__init__(name)
+        self.uri = uri
+        self.websocket = None
+
+    async def connect(self) -> None:
+        self.websocket = await websockets.connect(self.uri)
+        await self.websocket.send(json.dumps({"type": "register", "name": self.name}))
+        asyncio.create_task(self._listen())
+
+    async def _listen(self) -> None:
+        async for message in self.websocket:
+            data = json.loads(message)
+            await self.on_message(FIPAMessage(**data))
+
+    async def send(self, receiver: str, performative: str, content: str) -> None:
+        msg = FIPAMessage(
+            performative=performative,
+            sender=self.name,
+            receiver=receiver,
+            content=content,
+        )
+        await self.websocket.send(json.dumps(msg.__dict__))
+
+    async def on_message(self, message: FIPAMessage) -> None:
+        print(f"{self.name} received {message.performative} from {message.sender}: {message.content}")

--- a/websocket_bus.py
+++ b/websocket_bus.py
@@ -1,0 +1,36 @@
+import asyncio
+import json
+import websockets
+
+from fipa_acl import MessageBus
+
+
+class WebSocketMessageBus(MessageBus):
+    """Simple WebSocket-based message bus for FIPA agents."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.clients = {}
+
+    async def handler(self, websocket, path):
+        # Expect a registration message first
+        register_msg = await websocket.recv()
+        register = json.loads(register_msg)
+        if register.get("type") != "register":
+            await websocket.close()
+            return
+        name = register["name"]
+        self.clients[name] = websocket
+        try:
+            async for msg in websocket:
+                data = json.loads(msg)
+                receiver = data.get("receiver")
+                target = self.clients.get(receiver)
+                if target:
+                    await target.send(msg)
+        finally:
+            self.clients.pop(name, None)
+
+    async def start(self, host: str = "localhost", port: int = 8765) -> None:
+        async with websockets.serve(self.handler, host, port):
+            await asyncio.Future()  # run forever


### PR DESCRIPTION
## Summary
- integrate OpenAI API in commander/executor websocket demo
- Commander uses OpenAI to craft shell instructions and summarize results
- Executor translates natural language to shell commands with OpenAI and runs them
- document the new demo in the README

## Testing
- `python -m py_compile fipa_acl.py fipa_demo.py main.py websocket_agent.py websocket_bus.py commander_executor.py`
- `python commander_executor.py` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_686286f1c1208332b3747b2eda363abd