### PR TITLE
Add devcontainer Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/devcontainers/python:0-3.10
+
+# Install Python dependencies
+COPY requirements.txt /tmp/pip-tmp/
+RUN pip install --no-cache-dir -r /tmp/pip-tmp/requirements.txt
+RUN pip install --no-cache-dir openai
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,9 @@
 {
     "name": "MyLangChain",
-    "image": "mcr.microsoft.com/devcontainers/python:0-3.10",
-    "postCreateCommand": "pip install -r requirements.txt && pip install websockets",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
     "remoteEnv": {
         "OPENAI_API_KEY": "${OPENAI_API_KEY}"
     }


### PR DESCRIPTION
## Summary
- add Dockerfile to unify devcontainer environment
- build devcontainer from Dockerfile instead of base image
- install openai package during image build

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6863a5abc73c83329a7ee36e3921f24f